### PR TITLE
Update caching to custom sqlite-backed scheme

### DIFF
--- a/lmwrapper/_sqlcache_utils_profile.py
+++ b/lmwrapper/_sqlcache_utils_profile.py
@@ -5,7 +5,7 @@ import time
 from lmwrapper.abstract_predictor import get_mock_predictor
 from lmwrapper.caching import clear_cache_dir
 from lmwrapper.sqlcache import create_tables, SqlBackedCache
-from lmwrapper.structs import LmPrompt
+from lmwrapper.structs import LmPrompt, LmPrediction
 
 
 # Helper function to generate random text
@@ -42,13 +42,23 @@ def _profile_helper_get_predictions(cache, prompts):
     return end_time - start_time
 
 
-def _profile_cache():
+def _profile_cache(heavy_objs=False):
     clear_cache_dir()
-    lm = get_mock_predictor()
+    metad_size = 100_000 if heavy_objs else 10
+    lm = get_mock_predictor(lambda prompt: LmPrediction(
+        prompt.get_text_as_string_default_form(),
+        prompt,
+        metad={
+            k: v
+            for k, v in zip(range(100_000), range(100_000))
+        }
+    ))
     cache = SqlBackedCache(lm)
 
     # Create a list of 1000 random prompts for testing
-    prompts = [LmPrompt(_profile_helper_generate_random_text(50)) for _ in range(1000)]
+    prompts = [LmPrompt(_profile_helper_generate_random_text(
+        50 if not heavy_objs else 5000
+    )) for _ in range(1000)]
 
     # Generate predictions once
     predictions = [lm.predict(prompt.get_text_as_string_default_form()) for prompt in prompts]
@@ -87,7 +97,7 @@ def _profile_cache():
 
 
 def main():
-    _profile_cache()
+    _profile_cache(heavy_objs=True)
 
 
 if __name__ == "__main__":

--- a/lmwrapper/_sqlcache_utils_profile.py
+++ b/lmwrapper/_sqlcache_utils_profile.py
@@ -4,13 +4,13 @@ import time
 
 from lmwrapper.abstract_predictor import get_mock_predictor
 from lmwrapper.caching import clear_cache_dir
-from lmwrapper.sqlcache import create_tables, SqlBackedCache
-from lmwrapper.structs import LmPrompt, LmPrediction
+from lmwrapper.sqlcache import SqlBackedCache, create_tables
+from lmwrapper.structs import LmPrediction, LmPrompt
 
 
 # Helper function to generate random text
 def _profile_helper_generate_random_text(length):
-    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+    return "".join(random.choices(string.ascii_letters + string.digits, k=length))
 
 
 # Function to create cache tables
@@ -45,23 +45,25 @@ def _profile_helper_get_predictions(cache, prompts):
 def _profile_cache(heavy_objs=False):
     clear_cache_dir()
     metad_size = 100_000 if heavy_objs else 10
-    lm = get_mock_predictor(lambda prompt: LmPrediction(
-        prompt.get_text_as_string_default_form(),
-        prompt,
-        metad={
-            k: v
-            for k, v in zip(range(100_000), range(100_000))
-        }
-    ))
+    lm = get_mock_predictor(
+        lambda prompt: LmPrediction(
+            prompt.get_text_as_string_default_form(),
+            prompt,
+            metad={k: v for k, v in zip(range(100_000), range(100_000), strict=False)},
+        ),
+    )
     cache = SqlBackedCache(lm)
 
     # Create a list of 1000 random prompts for testing
-    prompts = [LmPrompt(_profile_helper_generate_random_text(
-        50 if not heavy_objs else 5000
-    )) for _ in range(1000)]
+    prompts = [
+        LmPrompt(_profile_helper_generate_random_text(50 if not heavy_objs else 5000))
+        for _ in range(1000)
+    ]
 
     # Generate predictions once
-    predictions = [lm.predict(prompt.get_text_as_string_default_form()) for prompt in prompts]
+    predictions = [
+        lm.predict(prompt.get_text_as_string_default_form()) for prompt in prompts
+    ]
 
     print("Profiling cache creation and usage...")
 

--- a/lmwrapper/_sqlcache_utils_profile.py
+++ b/lmwrapper/_sqlcache_utils_profile.py
@@ -1,0 +1,94 @@
+import random
+import string
+import time
+
+from lmwrapper.abstract_predictor import get_mock_predictor
+from lmwrapper.caching import clear_cache_dir
+from lmwrapper.sqlcache import create_tables, SqlBackedCache
+from lmwrapper.structs import LmPrompt
+
+
+# Helper function to generate random text
+def _profile_helper_generate_random_text(length):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=length))
+
+
+# Function to create cache tables
+def _profile_helper_create_cache():
+    create_tables()
+
+
+# Function to delete and recreate cache (used in setup)
+def _profile_helper_setup_create_cache():
+    clear_cache_dir()
+    _profile_helper_create_cache()
+
+
+# Function to add predictions to the cache
+def _profile_helper_add_predictions(cache, predictions):
+    start_time = time.time()
+    for pred in predictions:
+        cache.add(prediction=pred)
+    end_time = time.time()
+    return end_time - start_time
+
+
+# Function to get predictions from the cache
+def _profile_helper_get_predictions(cache, prompts):
+    start_time = time.time()
+    for prompt in prompts:
+        cache.get(prompt)
+    end_time = time.time()
+    return end_time - start_time
+
+
+def _profile_cache():
+    clear_cache_dir()
+    lm = get_mock_predictor()
+    cache = SqlBackedCache(lm)
+
+    # Create a list of 1000 random prompts for testing
+    prompts = [LmPrompt(_profile_helper_generate_random_text(50)) for _ in range(1000)]
+
+    # Generate predictions once
+    predictions = [lm.predict(prompt.get_text_as_string_default_form()) for prompt in prompts]
+
+    print("Profiling cache creation and usage...")
+
+    # Measure cache creation time
+    create_times = []
+    for _ in range(5):
+        clear_cache_dir()
+        start_time = time.time()
+        _profile_helper_create_cache()
+        end_time = time.time()
+        create_times.append(end_time - start_time)
+    create_time = sum(create_times) / len(create_times)
+    print(f"Cache creation time: {create_time:.4f} seconds")
+
+    # Measure time to add predictions to the cache
+    num_prompts = 10000
+    add_times = []
+    for _ in range(5):
+        clear_cache_dir()
+        add_time = _profile_helper_add_predictions(cache, predictions)
+        add_times.append(add_time)
+    add_time_avg = sum(add_times) / len(add_times)
+    print(f"Adding predictions time: {add_time_avg / num_prompts:.4f} seconds/prompt")
+
+    # Measure time to get predictions from the cache
+    get_times = []
+    for _ in range(5):
+        clear_cache_dir()
+        get_time = _profile_helper_get_predictions(cache, prompts)
+        get_times.append(get_time)
+    get_time_avg = sum(get_times) / len(get_times)
+    print(f"Getting predictions time: {get_time_avg / num_prompts:.4f} seconds/prompt")
+
+
+def main():
+    _profile_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/lmwrapper/abstract_predictor.py
+++ b/lmwrapper/abstract_predictor.py
@@ -38,7 +38,11 @@ class LmPredictor:
             #cache_key = (prompt, self._get_cache_key_metadata())
             cache_key = prompt
             if cache_key in self._disk_cache:
-                cache_copy = self._disk_cache.get(cache_key)
+                try:
+                    cache_copy = self._disk_cache.get(cache_key)
+                except OperationalError as e:
+                    print("Failed to get from cache", e)
+                    cache_copy = None
                 if cache_copy:
                     cache_copy = cache_copy.mark_as_cached()
                 return cache_copy

--- a/lmwrapper/abstract_predictor.py
+++ b/lmwrapper/abstract_predictor.py
@@ -15,7 +15,12 @@ class LmPredictor:
         cache_default: bool = False,
     ):
         self._cache_default = cache_default
-        self._disk_cache = get_disk_cache()
+        #self._disk_cache = get_disk_cache()
+        from lmwrapper.sqlcache import SqlBackedCache
+        self._disk_cache = SqlBackedCache(self)
+
+    def find_prediction_class(self, prompt):
+        return LmPrediction
 
     def predict(
         self,
@@ -29,7 +34,8 @@ class LmPredictor:
             )
         self._validate_prompt(prompt, raise_on_invalid=True)
         if should_cache:
-            cache_key = (prompt, self._get_cache_key_metadata())
+            #cache_key = (prompt, self._get_cache_key_metadata())
+            cache_key = prompt
             if cache_key in self._disk_cache:
                 cache_copy = self._disk_cache.get(cache_key)
                 if cache_copy:
@@ -37,7 +43,8 @@ class LmPredictor:
                 return cache_copy
             val = self._predict_maybe_cached(prompt)
             try:
-                self._disk_cache.set(cache_key, val)
+                #self._disk_cache.set(cache_key, val)
+                self._disk_cache.add(val)
             except OperationalError as e:
                 print("Failed to cache", e)
             return val

--- a/lmwrapper/abstract_predictor.py
+++ b/lmwrapper/abstract_predictor.py
@@ -51,22 +51,19 @@ class LmPredictor:
         else:
             return self._predict_maybe_cached(prompt)
 
-    def _cache_key_for_prompt(self, prompt):
-        return (prompt, self._get_cache_key_metadata())
-
     def remove_prompt_from_cache(
         self,
         prompt: str | LmPrompt,
     ) -> bool:
-        return self._disk_cache.delete(self._cache_key_for_prompt(prompt))
+        return self._disk_cache.delete(prompt)
 
     def _validate_prompt(self, prompt: LmPrompt, raise_on_invalid: bool = True) -> bool:
         """Called on prediction to make sure the prompt is valid for the model"""
         return True
 
     @abstractmethod
-    def _get_cache_key_metadata(self):
-        return {"name": type(self).__name__}
+    def get_model_cache_key(self):
+        return type(self).__name__
 
     @abstractmethod
     def _predict_maybe_cached(

--- a/lmwrapper/abstract_predictor.py
+++ b/lmwrapper/abstract_predictor.py
@@ -1,10 +1,9 @@
 from abc import abstractmethod
+from collections.abc import Callable
 from sqlite3 import OperationalError
-from typing import Callable
 
 from ratemate import RateLimit
 
-from lmwrapper.caching import get_disk_cache
 from lmwrapper.structs import LmPrediction, LmPrompt
 
 
@@ -16,8 +15,9 @@ class LmPredictor:
         cache_default: bool = False,
     ):
         self._cache_default = cache_default
-        #self._disk_cache = get_disk_cache()
+        # self._disk_cache = get_disk_cache()
         from lmwrapper.sqlcache import SqlBackedCache
+
         self._disk_cache = SqlBackedCache(self)
 
     def find_prediction_class(self, prompt):
@@ -35,7 +35,7 @@ class LmPredictor:
             )
         self._validate_prompt(prompt, raise_on_invalid=True)
         if should_cache:
-            #cache_key = (prompt, self._get_cache_key_metadata())
+            # cache_key = (prompt, self._get_cache_key_metadata())
             cache_key = prompt
             if cache_key in self._disk_cache:
                 try:
@@ -48,7 +48,7 @@ class LmPredictor:
                 return cache_copy
             val = self._predict_maybe_cached(prompt)
             try:
-                #self._disk_cache.set(cache_key, val)
+                # self._disk_cache.set(cache_key, val)
                 self._disk_cache.add(val)
             except OperationalError as e:
                 print("Failed to cache", e)
@@ -154,6 +154,7 @@ def get_mock_predictor(
     is_chat_model: bool = False,
 ):
     """Gets a mock predictor. By default returns whatever the prompt txt is"""
+
     class MockPredict(LmPredictor):
         def get_model_cache_key(self):
             return "mock_predictor"
@@ -164,6 +165,11 @@ def get_mock_predictor(
 
         def _predict_maybe_cached(self, prompt):
             if predict_func is None:
-                return LmPrediction(prompt.get_text_as_string_default_form(), prompt, {})
+                return LmPrediction(
+                    prompt.get_text_as_string_default_form(),
+                    prompt,
+                    {},
+                )
             return predict_func(prompt)
+
     return MockPredict()

--- a/lmwrapper/caching.py
+++ b/lmwrapper/caching.py
@@ -33,19 +33,19 @@ def _verify_looks_like_cache_dir(path: Path):
                 raise ValueError(msg)
 
 
-def _cache_dir() -> Path:
+def cache_dir() -> Path:
     if _set_cache_dir is not None:
         return _set_cache_dir
     return Path.cwd() / ".lmwrapper_cache"
 
 
 def _get_disk_cache_joblib() -> Memory:
-    return Memory(_cache_dir(), verbose=0)
+    return Memory(cache_dir(), verbose=0)
 
 
 def _get_disk_cache_diskcache() -> diskcache.FanoutCache:
     return diskcache.FanoutCache(
-        str(_cache_dir()),
+        str(cache_dir()),
         timeout=int(9e9),
         size_limit=50e9,
         shards=4,
@@ -60,5 +60,4 @@ def get_disk_cache():
 
 def clear_cache_dir():
     import shutil
-
-    shutil.rmtree(_cache_dir())
+    shutil.rmtree(cache_dir())

--- a/lmwrapper/caching.py
+++ b/lmwrapper/caching.py
@@ -60,5 +60,6 @@ def get_disk_cache():
 
 def clear_cache_dir():
     import shutil
+
     if cache_dir().exists():
         shutil.rmtree(cache_dir())

--- a/lmwrapper/caching.py
+++ b/lmwrapper/caching.py
@@ -60,4 +60,5 @@ def get_disk_cache():
 
 def clear_cache_dir():
     import shutil
-    shutil.rmtree(cache_dir())
+    if cache_dir().exists():
+        shutil.rmtree(cache_dir())

--- a/lmwrapper/caching.py
+++ b/lmwrapper/caching.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import diskcache
-from joblib import Memory
 
 cur_file = Path(__file__).parent.absolute()
 
@@ -39,11 +37,13 @@ def cache_dir() -> Path:
     return Path.cwd() / ".lmwrapper_cache"
 
 
-def _get_disk_cache_joblib() -> Memory:
+def _get_disk_cache_joblib():
+    from joblib import Memory
     return Memory(cache_dir(), verbose=0)
 
 
-def _get_disk_cache_diskcache() -> diskcache.FanoutCache:
+def _get_disk_cache_diskcache():
+    import diskcache
     return diskcache.FanoutCache(
         str(cache_dir()),
         timeout=int(9e9),

--- a/lmwrapper/huggingface_wrapper/__init__.py
+++ b/lmwrapper/huggingface_wrapper/__init__.py
@@ -1,2 +1,3 @@
 """Wrappers for openai transformers"""
+
 from lmwrapper.huggingface_wrapper.wrapper import *

--- a/lmwrapper/huggingface_wrapper/prediction.py
+++ b/lmwrapper/huggingface_wrapper/prediction.py
@@ -1,8 +1,8 @@
+import pickle
 from dataclasses import dataclass
 from typing import Any
 
 from lmwrapper.structs import LmPrediction, LmPrompt
-import pickle
 
 
 @dataclass
@@ -20,7 +20,7 @@ class HuggingFacePrediction(LmPrediction):
         completion_text: str,
         prompt: LmPrompt,
         metad_bytes: bytes,
-    ) -> 'HuggingFacePrediction':
+    ) -> "HuggingFacePrediction":
         metad_and_params = pickle.loads(metad_bytes)
         return cls(
             prompt=prompt,
@@ -28,20 +28,19 @@ class HuggingFacePrediction(LmPrediction):
             **metad_and_params,
         )
 
-    def serialize_metad_for_cache(
-        self
-    ) -> bytes:
+    def serialize_metad_for_cache(self) -> bytes:
         assert "prompt" not in self.metad
-        return pickle.dumps({
-            "metad": self.metad,
-            "_prompt_encoding": self._prompt_encoding,
-            "_tokens": self._tokens,
-            "_log_probs": self._log_probs,
-            "_logprobs_dict": self._logprobs_dict,
-            "_num_prompt_tokens": self._num_prompt_tokens,
-            "_completion_with_special_tok": self._completion_with_special_tok,
-        })
-
+        return pickle.dumps(
+            {
+                "metad": self.metad,
+                "_prompt_encoding": self._prompt_encoding,
+                "_tokens": self._tokens,
+                "_log_probs": self._log_probs,
+                "_logprobs_dict": self._logprobs_dict,
+                "_num_prompt_tokens": self._num_prompt_tokens,
+                "_completion_with_special_tok": self._completion_with_special_tok,
+            },
+        )
 
     def __post_init__(self):
         super().__post_init__()

--- a/lmwrapper/huggingface_wrapper/prediction.py
+++ b/lmwrapper/huggingface_wrapper/prediction.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from typing import Any
 
-from lmwrapper.structs import LmPrediction
+from lmwrapper.structs import LmPrediction, LmPrompt
+import pickle
 
 
 @dataclass
@@ -12,6 +13,34 @@ class HuggingFacePrediction(LmPrediction):
     _logprobs_dict: dict
     _num_prompt_tokens: int
     _completion_with_special_tok: str
+
+    @classmethod
+    def parse_from_cache(
+        cls,
+        completion_text: str,
+        prompt: LmPrompt,
+        metad_bytes: bytes,
+    ) -> 'HuggingFacePrediction':
+        metad_and_params = pickle.loads(metad_bytes)
+        return cls(
+            prompt=prompt,
+            completion_text=completion_text,
+            *metad_and_params,
+        )
+
+    def serialize_metad_for_cache(
+        self
+    ) -> bytes:
+        return pickle.dumps({
+            "metad": self.metad,
+            "_prompt_encoding": self._prompt_encoding,
+            "_tokens": self._tokens,
+            "_log_probs": self._log_probs,
+            "_logprobs_dict": self._logprobs_dict,
+            "_num_prompt_tokens": self._num_prompt_tokens,
+            "_completion_with_special_tok": self._completion_with_special_tok,
+        })
+
 
     def __post_init__(self):
         super().__post_init__()

--- a/lmwrapper/huggingface_wrapper/prediction.py
+++ b/lmwrapper/huggingface_wrapper/prediction.py
@@ -25,12 +25,13 @@ class HuggingFacePrediction(LmPrediction):
         return cls(
             prompt=prompt,
             completion_text=completion_text,
-            *metad_and_params,
+            **metad_and_params,
         )
 
     def serialize_metad_for_cache(
         self
     ) -> bytes:
+        assert "prompt" not in self.metad
         return pickle.dumps({
             "metad": self.metad,
             "_prompt_encoding": self._prompt_encoding,

--- a/lmwrapper/huggingface_wrapper/predictor.py
+++ b/lmwrapper/huggingface_wrapper/predictor.py
@@ -386,9 +386,9 @@ class HuggingFacePredictor(LmPredictor):
                     combined_logits = torch.cat(cached_logits, dim=1)
                 else:
                     combined_logits = cached_logits[-1]
-                if not (combined_logits.shape[1] == len(model_output_sequence[1:])):
+                if combined_logits.shape[1] != len(model_output_sequence[1:]):
                     msg = (
-                        f"Logits shape does not match the output sequence length\n"
+                        "Logits shape does not match the output sequence length\n"
                         f"Logits shape: {cached_logits.shape}\n"
                         f"Output sequence length: {len(model_output_sequence[1:])}"
                     )

--- a/lmwrapper/huggingface_wrapper/predictor.py
+++ b/lmwrapper/huggingface_wrapper/predictor.py
@@ -516,6 +516,9 @@ class HuggingFacePredictor(LmPredictor):
             _logprobs_dict=logprobs_dicts,
         )
 
+    def find_prediction_class(self, prompt):
+        return HuggingFacePrediction
+
     def _parse_model_internals_results(
         self,
         prompt: LmPrompt,

--- a/lmwrapper/huggingface_wrapper/predictor.py
+++ b/lmwrapper/huggingface_wrapper/predictor.py
@@ -42,11 +42,8 @@ class HuggingFacePredictor(LmPredictor):
         self.prompt_trimmer = prompt_trimmer
         self._tokenizer_already_adds_bos = {}
 
-    def _get_cache_key_metadata(self):
-        return {
-            "model": "HuggingFacePredictor",
-            "name_or_path": self._model.name_or_path,
-        }
+    def get_model_cache_key(self):
+        return self._model.name_or_path
 
     def _verify_initial_prompt(self, prompt: LmPrompt):
         if not isinstance(prompt.text, str) and len(prompt.text) != 1:

--- a/lmwrapper/openai_wrapper/__init__.py
+++ b/lmwrapper/openai_wrapper/__init__.py
@@ -1,4 +1,5 @@
 """
 Wrappers for openai
 """
+
 from lmwrapper.openai_wrapper.wrapper import *

--- a/lmwrapper/openai_wrapper/wrapper.py
+++ b/lmwrapper/openai_wrapper/wrapper.py
@@ -51,10 +51,7 @@ class OpenAiLmPrediction(LmPrediction):
         if not probably_chat:
             return self.metad.logprobs.tokens
         else:
-            return [
-                lp.token
-                for lp in self.metad.logprobs.content
-            ]
+            return [lp.token for lp in self.metad.logprobs.content]
 
     def _all_toks_offsets(self):
         return self.metad.logprobs.text_offset
@@ -67,10 +64,7 @@ class OpenAiLmPrediction(LmPrediction):
         if not probably_chat:
             return self.metad.logprobs.token_logprobs
         else:
-            return [
-                lp.logprob
-                for lp in self.metad.logprobs.content
-            ]
+            return [lp.logprob for lp in self.metad.logprobs.content]
 
     @property
     def completion_tokens(self):

--- a/lmwrapper/openai_wrapper/wrapper.py
+++ b/lmwrapper/openai_wrapper/wrapper.py
@@ -212,6 +212,11 @@ class OpenAIPredictor(LmPredictor):
         """
         cls._instantiation_hooks.append(hook)
 
+    def find_prediction_class(self, prompt):
+        if self._chat_mode:
+            return OpenAiLmChatPrediction
+        return OpenAiLmPrediction
+
     def _validate_prompt(self, prompt: LmPrompt, raise_on_invalid: bool = True) -> bool:
         if prompt.logprobs is not None and prompt.logprobs > MAX_LOG_PROB_PARM:
             warnings.warn(

--- a/lmwrapper/openai_wrapper/wrapper.py
+++ b/lmwrapper/openai_wrapper/wrapper.py
@@ -224,14 +224,14 @@ class OpenAIPredictor(LmPredictor):
                 " might cause unexpected behavior if you later are dependingon more"
                 " returns",
             )
+            return False
+        return True
 
     def model_name(self):
         return self._engine_name
 
-    def _get_cache_key_metadata(self):
-        return {
-            "engine": self._engine_name,
-        }
+    def get_model_cache_key(self):
+        return "OpenAI::" + self._engine_name
 
     def list_engines(self):
         return self._api.Engine.list()

--- a/lmwrapper/sqlcache.py
+++ b/lmwrapper/sqlcache.py
@@ -9,14 +9,14 @@ from lmwrapper.structs import LmPrediction, LmPrompt
 import os
 
 _text_hash_len = 32
-_text_and_sample_hash_len = 48
+_text_and_sample_hash_len = 43
 
 cache_path_fn = lambda: cache_dir() / "lm_cache.db"
 
 
 def execute_query(
-        query: str | list[str | tuple[str, tuple[any, ...]]] | tuple[str, tuple[any, ...]],
-        fetchone=False
+    query: str | list[str | tuple[str, tuple[any, ...]]] | tuple[str, tuple[any, ...]],
+    fetchone=False
 ):
     with sqlite3.connect(cache_path_fn()) as conn:
         cursor = conn.cursor()

--- a/lmwrapper/sqlcache.py
+++ b/lmwrapper/sqlcache.py
@@ -1,0 +1,223 @@
+import peewee
+import datetime
+import base64
+import xxhash
+from peewee import TextField
+
+from lmwrapper.abstract_predictor import LmPredictor
+from lmwrapper.caching import cache_dir
+from lmwrapper.openai_wrapper import get_open_ai_lm
+from lmwrapper.structs import LmPrediction, LmPrompt
+
+_tables_created = False
+_text_hash_len = 32
+_text_and_sample_hash_len = 48
+
+database = peewee.SqliteDatabase(cache_dir() / 'cache_db.sqlite3')
+
+
+class BaseModel(peewee.Model):
+    class Meta:
+        database = database
+
+
+class CacheLmPromptText(BaseModel):
+    text_hash = peewee.FixedCharField(
+        primary_key=True, max_length=_text_hash_len)
+    text = TextField()
+
+    @classmethod
+    def create_from_prompt(cls, prompt: LmPrompt):
+        return cls.get_or_create(
+            text_hash=prompt_to_text_hash(prompt),
+            text=prompt.get_text_as_string_default_form()
+        )[0]
+
+
+def prompt_to_text_hash(prompt: LmPrompt) -> str:
+    text = prompt.get_text_as_string_default_form()
+    hasher = xxhash.xxh64()
+    hasher.update(text.encode())
+    text_hash = base64.b64encode(hasher.digest()).decode()
+    # Add the start and end of the text to make it the right length
+    #  this ideally also improves locality of the hash
+    remaining_chars = _text_hash_len - len(text_hash)
+    start_chars = text[:min(remaining_chars // 3, len(text))]
+    end_chars = text[-min(remaining_chars - len(start_chars), len(text)):]
+    text_hash = start_chars + end_chars[::-1] + text_hash
+    # Ensure it is the right length
+    if len(text_hash) < _text_hash_len:
+        text_hash += "_" * (_text_hash_len - len(text_hash))
+    return text_hash
+
+
+def prompt_to_sample_hash_text(
+    prompt: LmPrompt,
+    model_key: str,
+) -> str:
+    return (
+        prompt_to_text_hash(prompt)
+        + prompt_to_sample_params_hash(prompt, model_key)
+    )
+
+
+def prompt_to_sample_params_hash(
+    prompt: LmPrompt,
+    model_key: str,
+) -> str:
+    _target_len = _text_and_sample_hash_len - _text_hash_len
+    hasher = xxhash.xxh64()
+    hasher.update(
+        str(CacheLmPromptSampleParams.prompt_to_only_sample_class_dict(prompt, model_key))
+    )
+    hash = base64.b64encode(hasher.digest()).decode()
+    if len(hash) < _target_len:
+        hash += "_" * (_target_len - len(hash))
+    elif len(hash) > _target_len:
+        hash = hash[:_target_len]
+    return hash
+
+
+class CacheLmPromptSampleParams(BaseModel):
+    text_hash = peewee.ForeignKeyField(CacheLmPromptText)
+    sample_hash = peewee.FixedCharField(
+        max_length=_text_and_sample_hash_len,
+        primary_key=True,
+    )
+    model_key = peewee.CharField()
+    max_tokens = peewee.IntegerField(null=True)
+    temperature = peewee.FloatField()
+    top_p = peewee.FloatField()
+    presence_penalty = peewee.FloatField()
+    frequency_penalty = peewee.FloatField()
+    add_bos_token = peewee.CharField()
+    echo = peewee.BooleanField()
+    add_special_tokens = peewee.BooleanField()
+    has_internals_request = peewee.BooleanField()
+    stop = peewee.TextField()
+
+    @classmethod
+    def prompt_to_only_sample_class_dict(
+        cls,
+        prompt: LmPrompt,
+        model_key: model_key,
+    ):
+        return dict(
+            model_key=model_key,
+            max_tokens=prompt.max_tokens,
+            temperature=prompt.temperature,
+            top_p=prompt.top_p,
+            presence_penalty=prompt.presence_penalty,
+            frequency_penalty=prompt.frequency_penalty,
+            add_bos_token=str(prompt.add_bos_token),
+            echo=prompt.echo,
+            add_special_tokens=prompt.add_special_tokens,
+            has_internals_request=prompt.model_internals_request is not None,
+            stop=str(prompt.stop),
+        )
+
+    @classmethod
+    def create_from_prompt(
+        cls,
+        prompt: LmPrompt,
+        model_key: str,
+    ):
+        # Get or create
+        textcache = CacheLmPromptText.create_from_prompt(prompt)
+        instance, created = cls.get_or_create(
+            text_hash=textcache.text_hash,
+            sample_hash=prompt_to_sample_hash_text(prompt, model_key),
+            **cls.prompt_to_only_sample_class_dict(prompt, model_key),
+        )
+        return instance
+
+
+class CacheLmPrediction(BaseModel):
+    sample_params = peewee.FixedCharField(
+        max_length=_text_and_sample_hash_len,
+    )
+    base_class = peewee.CharField()
+    completion_text = peewee.TextField()
+    metad_bytes = peewee.BlobField()
+    date_added = peewee.DateTimeField()
+
+
+def create_tables():
+    with database:
+        database.create_tables([
+            CacheLmPromptText,
+            CacheLmPromptSampleParams, CacheLmPrediction
+        ])
+
+
+def _prep_cache():
+    global _tables_created
+    if not _tables_created:
+        create_tables()
+        _tables_created = True
+
+
+def add_prediction_to_cache(
+    prediction: LmPrediction,
+    model_key: str,
+):
+    _prep_cache()
+    sample_params = CacheLmPromptSampleParams.create_from_prompt(
+        prediction.prompt,
+        model_key,
+    )
+    print("sample_params made", sample_params.sample_hash)
+    CacheLmPrediction.create(
+        sample_params=sample_params,
+        base_class=prediction.__class__.__name__,
+        completion_text=prediction.completion_text,
+        metad_bytes=prediction.serialize_metad_for_cache(),
+        date_added=datetime.datetime.now(),
+    )
+
+
+def get_from_cache(
+    prompt: LmPrompt,
+    lm: LmPredictor = None,
+) -> LmPrediction | None:
+    _prep_cache()
+    sample_hash = prompt_to_sample_hash_text(prompt, lm.model_name())
+    res = CacheLmPrediction.select().where(
+        CacheLmPrediction.sample_params == sample_hash
+    )
+    res = list(res)
+    assert prompt.num_completions == 1
+    if not res:
+        return None
+    res = res[0]
+    return lm.find_prediction_class(prompt).parse_from_cache(
+        res.completion_text,
+        prompt,
+        res.metad_bytes,
+    )
+
+
+def main():
+    create_tables()
+    lm = get_open_ai_lm()
+    pred = lm.predict("Once upon a time")
+    add_prediction_to_cache(pred, lm.model_name())
+
+
+class SqlBackedCache:
+    def __init__(self, lm):
+        create_tables()
+        self._lm = lm
+
+    def __contains__(self, prompt: LmPrompt):
+        return get_from_cache(prompt, self._lm) is not None
+
+    def get(self, prompt: LmPrompt):
+        return get_from_cache(prompt, self._lm)
+
+    def add(self, prediction: LmPrediction):
+        add_prediction_to_cache(prediction, self._lm.model_name())
+
+
+if __name__ == "__main__":
+    main()

--- a/lmwrapper/structs.py
+++ b/lmwrapper/structs.py
@@ -1,12 +1,11 @@
 import contextlib
+import pickle
 import statistics
 from dataclasses import dataclass, field
 from typing import Any, Optional, Union
 
 from lmwrapper.interals import ModelInternalsResults
 from lmwrapper.utils import StrEnum
-import pickle
-import json
 
 LM_CHAT_DIALOG_COERCIBLE_TYPES = Union[
     str,
@@ -17,6 +16,7 @@ LM_CHAT_DIALOG_COERCIBLE_TYPES = Union[
 
 class StopMode(StrEnum):
     """Determines how to try to handle stop tokens"""
+
     WILL_NOT_CONTAIN = "WILL_NOT_CONTAIN"
     """This emulates the classic openai completion API. This makes
     sure the returned sequence will not contain the stop token.
@@ -171,7 +171,7 @@ class LmPrompt:
             )
         if self.stop_mode != StopMode.AUTO:
             raise NotImplementedError(
-                "Only StopMode.AUTO is supported at this time as a temporary hack"
+                "Only StopMode.AUTO is supported at this time as a temporary hack",
             )
 
     def is_text_a_chat(self) -> bool:
@@ -316,9 +316,7 @@ class LmPrediction:
             metad=pickle.loads(metad_bytes),
         )
 
-    def serialize_metad_for_cache(
-        self
-    ) -> bytes:
+    def serialize_metad_for_cache(self) -> bytes:
         return pickle.dumps(self.metad)
 
     def __post_init__(self):

--- a/lmwrapper/structs.py
+++ b/lmwrapper/structs.py
@@ -124,6 +124,9 @@ class LmPrompt:
     # TODO: make a auto_reduce_max_tokens to reduce when might go over.
 
     def __post_init__(self):
+        if isinstance(self.text, list):
+            # Convert the text into a chat dialog
+            object.__setattr__(self, "text", LmChatDialog(self.text))
         if self.max_tokens is not None and not isinstance(self.max_tokens, int):
             msg = "The max_tokens parameter should be an int."
             raise ValueError(msg)
@@ -172,7 +175,7 @@ class LmPrompt:
             )
 
     def is_text_a_chat(self) -> bool:
-        return isinstance(self.text, list)
+        return isinstance(self.text, LmChatDialog)
 
     def get_text_as_chat(self) -> "LmChatDialog":
         return LmChatDialog(self.text)

--- a/lmwrapper/structs.py
+++ b/lmwrapper/structs.py
@@ -163,6 +163,10 @@ class LmPrompt:
             raise ValueError(
                 msg,
             )
+        if self.stop_mode != StopMode.AUTO:
+            raise NotImplementedError(
+                "Only StopMode.AUTO is supported at this time as a temporary hack"
+            )
 
     def is_text_a_chat(self) -> bool:
         return isinstance(self.text, list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = ["lmwrapper*"]
 
 [project]
 name = "lmwrapper"
-version = "0.9.4.0"
+version = "0.9.4.1"
 authors = [
     { name = "David Gros" },
     { name = "Claudio Spiess" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,12 @@ classifiers = ["Programming Language :: Python :: 3"]
 keywords = ["large language models", "openai"]
 dependencies = [
     "openai~=1.14.0",
-    "diskcache~=5.6.3",
-    "joblib~=1.3.2",
+    #"diskcache~=5.6.3",
+    #"joblib~=1.3.2",
     "tiktoken~=0.5.1",
     "ratemate~=0.1",
     "humanize~=4.8.0",
+    "xxhash~=3.4"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = ["lmwrapper*"]
 
 [project]
 name = "lmwrapper"
-version = "0.9.4.1"
+version = "0.10.0.0"
 authors = [
     { name = "David Gros" },
     { name = "Claudio Spiess" },

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -1,7 +1,6 @@
 import dataclasses
-import random
 import multiprocessing
-import time
+import random
 import tempfile
 from pathlib import Path
 
@@ -42,6 +41,7 @@ def test_set_cache_dir():
 def test_cache_stress_random():
     prompts = [LmPrompt(f"Prompt {i}", cache=True) for i in range(100)]
     import random
+
     lm = get_mock_predictor()
     for _ in range(10_000):
         prompt = random.choice(prompts)
@@ -51,14 +51,16 @@ def test_cache_stress_random():
 def test_cache_stress_random_multithread():
     prompts = [LmPrompt(f"Prompt {i}", cache=True) for i in range(100)]
     import random
+
     lm = get_mock_predictor()
     import threading
-    import time
+
     def worker():
         for _ in range(1_000):
             prompt = random.choice(prompts)
             pred = lm.predict(prompt)
             assert pred.completion_text == prompt.get_text_as_string_default_form()
+
     threads = [threading.Thread(target=worker) for _ in range(10)]
     for t in threads:
         t.start()

--- a/test/test_caching.py
+++ b/test/test_caching.py
@@ -57,7 +57,8 @@ def test_cache_stress_random_multithread():
     def worker():
         for _ in range(1_000):
             prompt = random.choice(prompts)
-            lm.predict(prompt)
+            pred = lm.predict(prompt)
+            assert pred.completion_text == prompt.get_text_as_string_default_form()
     threads = [threading.Thread(target=worker) for _ in range(10)]
     for t in threads:
         t.start()
@@ -70,6 +71,7 @@ def _worker_multiproc():
     for _ in range(10_000):
         prompt = random.choice(prompts)
         pred = lm.predict(prompt)
+        assert pred.completion_text == prompt.get_text_as_string_default_form()
         if pred.was_cached:
             num_hits += 1
     assert num_hits > 9000

--- a/test/test_caching_sql.py
+++ b/test/test_caching_sql.py
@@ -1,3 +1,4 @@
+from lmwrapper.abstract_predictor import get_mock_predictor
 from lmwrapper.caching import clear_cache_dir
 from lmwrapper.openai_wrapper import get_open_ai_lm
 from lmwrapper.sqlcache import add_prediction_to_cache, prompt_to_text_hash, get_from_cache

--- a/test/test_caching_sql.py
+++ b/test/test_caching_sql.py
@@ -1,0 +1,42 @@
+from lmwrapper.caching import clear_cache_dir
+from lmwrapper.openai_wrapper import get_open_ai_lm
+from lmwrapper.sqlcache import add_prediction_to_cache, prompt_to_text_hash, get_from_cache
+from lmwrapper.structs import LmPrompt
+import lmwrapper.sqlcache as sqlcache
+
+
+def test_add_cache():
+    clear_cache_dir()
+    lm = get_open_ai_lm()
+    pred = lm.predict("Once upon a time")
+    add_prediction_to_cache(pred, lm.model_name())
+
+
+def test_get_cache():
+    clear_cache_dir()
+    lm = get_open_ai_lm()
+    model_key = lm.model_name()
+    prompt = LmPrompt("Once upon a time", cache=True)
+    assert get_from_cache(prompt, lm) is None
+    pred = lm.predict(prompt)
+    add_prediction_to_cache(pred, model_key)
+    ret = get_from_cache(prompt, lm)
+    assert ret is not None
+    assert ret.completion_text == pred.completion_text
+    assert pred == ret
+    prompt2 = LmPrompt("Once upon a time", cache=True)
+    assert get_from_cache(prompt2, lm) is not None
+    assert get_from_cache(LmPrompt("blah", cache=True), lm) is None
+
+
+def test_text_hash():
+    clear_cache_dir()
+    prompt = LmPrompt("hello world")
+    hash = prompt_to_text_hash(prompt)
+    assert hash == prompt_to_text_hash(prompt)
+    assert hash != prompt_to_text_hash(LmPrompt("hello world!"))
+    assert len(hash) == sqlcache._text_hash_len
+    assert len(prompt_to_text_hash(LmPrompt(""))) == sqlcache._text_hash_len
+    assert len(prompt_to_text_hash(LmPrompt("d"*500))) == sqlcache._text_hash_len
+    assert len(prompt_to_text_hash(LmPrompt(["foo", "bar"]))) == sqlcache._text_hash_len
+    print(hash)

--- a/test/test_caching_sql.py
+++ b/test/test_caching_sql.py
@@ -1,9 +1,12 @@
-from lmwrapper.abstract_predictor import get_mock_predictor
+from lmwrapper import sqlcache
 from lmwrapper.caching import clear_cache_dir
 from lmwrapper.openai_wrapper import get_open_ai_lm
-from lmwrapper.sqlcache import add_prediction_to_cache, prompt_to_text_hash, get_from_cache
+from lmwrapper.sqlcache import (
+    add_prediction_to_cache,
+    get_from_cache,
+    prompt_to_text_hash,
+)
 from lmwrapper.structs import LmPrompt
-import lmwrapper.sqlcache as sqlcache
 
 
 def test_add_cache():
@@ -38,6 +41,6 @@ def test_text_hash():
     assert hash != prompt_to_text_hash(LmPrompt("hello world!"))
     assert len(hash) == sqlcache._text_hash_len
     assert len(prompt_to_text_hash(LmPrompt(""))) == sqlcache._text_hash_len
-    assert len(prompt_to_text_hash(LmPrompt("d"*500))) == sqlcache._text_hash_len
+    assert len(prompt_to_text_hash(LmPrompt("d" * 500))) == sqlcache._text_hash_len
     assert len(prompt_to_text_hash(LmPrompt(["foo", "bar"]))) == sqlcache._text_hash_len
     print(hash)

--- a/test/test_huggingface.py
+++ b/test/test_huggingface.py
@@ -1,4 +1,6 @@
 # test
+import os
+
 import numpy as np
 import pytest
 import torch
@@ -14,7 +16,6 @@ from lmwrapper.prompt_trimming import HfTokenTrimmer
 from lmwrapper.runtime import Runtime
 from lmwrapper.structs import LmPrompt
 from lmwrapper.utils import StrEnum
-import os
 
 
 class Models(StrEnum):
@@ -854,7 +855,7 @@ def test_tokenizer_offsets_code_llama():
     assert list(starts) == expected_offsets
 
 
-#@pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
+# @pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
 @pytest.mark.skip(reason="Mistral seems broken with gating error")
 def test_offsets_for_mistral():
     model_name = Models.Mistral_7B
@@ -872,7 +873,7 @@ def test_offsets_for_mistral():
     ]
 
 
-#@pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
+# @pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
 @pytest.mark.skip(reason="Mistral seems broken with gating error")
 def test_offsets_for_mistral2():
     model_name = Models.Mistral_7B
@@ -889,7 +890,7 @@ def test_offsets_for_mistral2():
     ]
 
 
-#@pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
+# @pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
 @pytest.mark.skip(reason="Mistral seems broken with gating error")
 def test_offsets_for_mistral3():
     model_name = Models.Mistral_7B
@@ -1041,7 +1042,7 @@ def test_hello_world_prompt(model):
     }
 
 
-#@pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
+# @pytest.mark.skipif(IS_GITHUB_ACTIONS, reason="Can't load tokenizer on GitHub Actions")
 @pytest.mark.skip(reason="Mistral seems broken with gating error")
 def test_check_tokenizer_check():
     mistral_tokenizer = AutoTokenizer.from_pretrained(Models.Mistral_7B, use_fast=True)

--- a/test/test_huggingface_internals.py
+++ b/test/test_huggingface_internals.py
@@ -4,11 +4,11 @@ from test.test_huggingface import BIG_MODELS, Models
 
 import numpy as np
 import pytest
+import torch
 
 from lmwrapper.huggingface_wrapper import get_huggingface_lm
 from lmwrapper.interals import ModelInternalsRequest
 from lmwrapper.structs import LmPrompt
-import torch
 
 IS_GITHUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
 
@@ -28,8 +28,10 @@ def test_get_internals_hidden_states(pytestconfig, model_name_layers_hidden):
     model_name, num_layers, hidden_size = model_name_layers_hidden
     is_run_slow = pytestconfig.getoption("--runslow")
     if IS_GITHUB_ACTIONS and model_name != Models.GPT2:
-        pytest.skip("We are only going to test gpt2 here. "
-                    "The other models are either large or use a similar attention pattern.")
+        pytest.skip(
+            "We are only going to test gpt2 here. "
+            "The other models are either large or use a similar attention pattern.",
+        )
     if IS_GITHUB_ACTIONS and model_name in BIG_MODELS:
         pytest.skip("skip big models in github actions")
     model = get_huggingface_lm(model_name, trust_remote_code=True)
@@ -50,7 +52,9 @@ def test_get_internals_hidden_states(pytestconfig, model_name_layers_hidden):
     def check_vals(pred, prompt):
         assert pred.internals.hidden_states is not None
         assert isinstance(pred.internals.hidden_states, tuple)
-        assert len(pred.internals.hidden_states) == 1 + num_layers  # has embedding layer
+        assert (
+            len(pred.internals.hidden_states) == 1 + num_layers
+        )  # has embedding layer
         assert all(isinstance(x, np.ndarray) for x in pred.internals.hidden_states)
         assert all(
             x.shape == (num_expected_tokens, hidden_size)

--- a/test/test_models_common.py
+++ b/test/test_models_common.py
@@ -292,8 +292,8 @@ def test_stopping_begin_tok_full_tok(lm):
     assert "is the city Paris" in val_normal.completion_text
     assert len(val_normal.completion_tokens) == 4
     assert (
-            lm.remove_special_chars_from_tokens(val_normal.completion_tokens)[-1]
-            == " Paris"
+        lm.remove_special_chars_from_tokens(val_normal.completion_tokens)[-1]
+        == " Paris"
     )
     val_no_pa = lm.predict(
         LmPrompt(
@@ -740,5 +740,5 @@ def test_echo_many_toks(lm):
     assert np.allclose(
         np.exp(out2.completion_logprobs),
         np.exp(out.completion_logprobs),
-        atol=0.001
+        atol=0.001,
     )


### PR DESCRIPTION
This replaces the caching mechanism powered by `diskcache` (which internally pickles objects and puts them in an sqlite db) with one with a specialized sqlite schema. This is to give more flexibility with managing the cache and make way for a sensible way of doing things like abstracting the openai batching or assistants api. 